### PR TITLE
Refactor ban user modal logic and enhance users list.

### DIFF
--- a/src/app/users-list/modalUsersList/banUserModal.tsx
+++ b/src/app/users-list/modalUsersList/banUserModal.tsx
@@ -1,11 +1,10 @@
-import { useMutation } from "@apollo/client";
-import { MutationBanUserArgs } from "graphql/generated";
+import { ApolloQueryResult, useMutation } from "@apollo/client";
+import { GetUsersQuery, MutationBanUserArgs } from "graphql/generated";
 import { BAN_USER } from "apollo/mutations/user";
-import { Select, Typography, ConfirmModal, Textarea } from "common/components";
+import { ConfirmModal, Select, Textarea, Typography } from "common/components";
 import { SelectItemsProps } from "common/types";
 import { useEffect, useState } from "react";
 import s from "./modalUsersList.module.css";
-import { GET_USERS } from "apollo/queries/users";
 import { BAN_REASONS } from "common/constants/userMutationConstants";
 
 type Props = {
@@ -13,17 +12,17 @@ type Props = {
   onClose: () => void;
   userId: number;
   userName: string;
+  refetch: () => Promise<ApolloQueryResult<GetUsersQuery>>;
 };
 
-export const BanUserModal = ({ isOpen, userId, onClose, userName }: Props) => {
-  const [banUser] = useMutation<{ banUser: boolean }, MutationBanUserArgs>(BAN_USER, {
-    refetchQueries: [{ query: GET_USERS }],
-  });
+export const BanUserModal = ({ isOpen, userId, onClose, userName, refetch }: Props) => {
+  const [banUser] = useMutation<{ banUser: boolean }, MutationBanUserArgs>(BAN_USER);
 
   const { badBehavior, adPlacement, another } = BAN_REASONS;
 
   const handleBanUser = async (userId: number, banReason: string) => {
     await banUser({ variables: { userId, banReason } });
+    await refetch();
     onClose();
   };
 

--- a/src/app/users-list/page.tsx
+++ b/src/app/users-list/page.tsx
@@ -24,7 +24,7 @@ export default function UsersList() {
   const isLoggedIn = isLoggedInVar();
   const router = useRouter();
   const searchParams = useSearchParams();
-  const {searchUser, handleSearch, handleSort, setSearchUser} = useSearch();
+  const { searchUser, handleSearch, handleSort, setSearchUser } = useSearch();
   const [isModalOpen, setIsModalOpen] = useState<{ type: string; userId: number } | null>(null);
 
   const currentPage = Number(searchParams.get("page")) || DEFAULT_PAGE;
@@ -88,9 +88,7 @@ export default function UsersList() {
               className={s.selectStatusFilter}
               placeholder="Not selected"
               value={searchUser.statusFilter}
-              onValueChange={(value: UserBlockStatus) =>
-                setSearchUser({ ...searchUser, statusFilter: value })
-              }
+              onValueChange={(value: UserBlockStatus) => setSearchUser({ ...searchUser, statusFilter: value })}
               items={statusOptions}
             />
           </div>
@@ -156,6 +154,7 @@ export default function UsersList() {
                     isOpen={isModalOpen?.type === "ban" && isModalOpen.userId === user.id}
                     onClose={handleClose}
                     userName={user.userName}
+                    refetch={refetch}
                   />
                   <UnbanUserModal
                     userId={isModalOpen?.type === "unban" ? isModalOpen.userId : 0}


### PR DESCRIPTION
Replaced `refetchQueries` with explicit `refetch` prop in `BanUserModal` for more controlled reloading of user data. Adjusted imports and formatting for better readability and consistency across files. These changes streamline data updates and improve maintainability.